### PR TITLE
AnnotationRetention changed from SOURCE to RUNTIME

### DIFF
--- a/core/src/main/java/com/epam/coroutinecache/annotations/Expirable.kt
+++ b/core/src/main/java/com/epam/coroutinecache/annotations/Expirable.kt
@@ -4,6 +4,6 @@ package com.epam.coroutinecache.annotations
  * Annotation class using to set caching function expirable value to true. 
  * It means that function's result could be deleted from persistence if persistence reached its memory limit.
  */
-@Retention(AnnotationRetention.SOURCE)
+@Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.FUNCTION)
 annotation class Expirable

--- a/core/src/main/java/com/epam/coroutinecache/annotations/LifeTime.kt
+++ b/core/src/main/java/com/epam/coroutinecache/annotations/LifeTime.kt
@@ -8,6 +8,6 @@ import java.util.concurrent.TimeUnit
  * @param value - number that describes lifetime
  * @param unit - TimeUnit of lifetime
  */
-@Retention(AnnotationRetention.SOURCE)
+@Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.FUNCTION)
 annotation class LifeTime (val value: Long, val unit: TimeUnit)

--- a/core/src/main/java/com/epam/coroutinecache/annotations/ProviderKey.kt
+++ b/core/src/main/java/com/epam/coroutinecache/annotations/ProviderKey.kt
@@ -5,6 +5,6 @@ package com.epam.coroutinecache.annotations
  *
  * @param key - data's key in cache
  */
-@Retention(AnnotationRetention.SOURCE)
+@Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.FUNCTION)
 annotation class ProviderKey(val key: String)

--- a/core/src/main/java/com/epam/coroutinecache/annotations/UseIfExpired.kt
+++ b/core/src/main/java/com/epam/coroutinecache/annotations/UseIfExpired.kt
@@ -4,6 +4,6 @@ package com.epam.coroutinecache.annotations
  * If this annotation is applying to function, user will get data from cache even lifetime is exceeded
  * When data is received, they will be deleted from cache.
  */
-@Retention(AnnotationRetention.SOURCE)
+@Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.FUNCTION)
 annotation class UseIfExpired


### PR DESCRIPTION
Changed AnnotationRetention for annotations to retrieve them in runtime via reflection according to issue https://github.com/epam/CoroutinesCache/issues/12
