### PR TITLE
Change API of CacheProviders to accept suspend functions instead of Deferred

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -31,8 +31,8 @@ dependencies {
     implementation 'com.android.support:appcompat-v7:28.0.0'
     implementation 'com.android.support.constraint:constraint-layout:1.1.3'
 
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.0.0'
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.0.0'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.1.1'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.1.1'
 
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
@@ -42,8 +42,8 @@ dependencies {
     implementation 'com.squareup.moshi:moshi:1.6.0'
     implementation 'com.fasterxml.jackson.core:jackson-core:2.9.6'
 
-    implementation 'com.squareup.retrofit2:retrofit:2.4.0'
-    implementation "com.squareup.retrofit2:converter-gson:2.4.0"
+    implementation 'com.squareup.retrofit2:retrofit:2.6.0-SNAPSHOT'
+    implementation "com.squareup.retrofit2:converter-gson:2.5.0"
 
     implementation 'com.jakewharton.retrofit:retrofit2-kotlin-coroutines-adapter:0.9.2'
 }

--- a/app/src/main/java/com/epam/example/coroutinescache/CacheProviders.kt
+++ b/app/src/main/java/com/epam/example/coroutinescache/CacheProviders.kt
@@ -13,5 +13,5 @@ interface CacheProviders {
     @LifeTime(value = 1L, unit = TimeUnit.MINUTES)
     @Expirable
     @UseIfExpired
-    fun getData(data: Deferred<Data>): Deferred<Data>
+    fun getData(dataProvider: suspend () -> Data): Deferred<Data>
 }

--- a/app/src/main/java/com/epam/example/coroutinescache/Repository.kt
+++ b/app/src/main/java/com/epam/example/coroutinescache/Repository.kt
@@ -3,7 +3,6 @@ package com.epam.example.coroutinescache
 import com.epam.coroutinecache.api.CacheParams
 import com.epam.coroutinecache.api.CoroutinesCache
 import com.epam.coroutinecache.mappers.GsonMapper
-import com.jakewharton.retrofit2.adapter.kotlin.coroutines.CoroutineCallAdapterFactory
 import kotlinx.coroutines.Deferred
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
@@ -17,11 +16,10 @@ class Repository (
 
     private val restApi: RestApi = Retrofit.Builder ()
             .baseUrl("https://jsonplaceholder.typicode.com")
-            .addCallAdapterFactory(CoroutineCallAdapterFactory())
             .addConverterFactory(GsonConverterFactory.create())
             .build().create(RestApi::class.java)
 
     private val cacheProviders: CacheProviders = coroutinesCache.using(CacheProviders::class.java)
 
-    fun getData(): Deferred<Data> = cacheProviders.getData(restApi.getData())
+    fun getData(): Deferred<Data> = cacheProviders.getData(restApi::getData)
 }

--- a/app/src/main/java/com/epam/example/coroutinescache/RestApi.kt
+++ b/app/src/main/java/com/epam/example/coroutinescache/RestApi.kt
@@ -1,10 +1,9 @@
 package com.epam.example.coroutinescache
 
-import kotlinx.coroutines.Deferred
 import retrofit2.http.GET
 
 interface RestApi {
 
     @GET("todos/1")
-    fun getData(): Deferred<Data>
+    suspend fun getData(): Data
 }

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,8 @@ allprojects {
     repositories {
         google()
         jcenter()
+
+        maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
     }
 }
 

--- a/core/src/main/java/com/epam/coroutinecache/internal/CacheObjectParams.kt
+++ b/core/src/main/java/com/epam/coroutinecache/internal/CacheObjectParams.kt
@@ -1,7 +1,7 @@
 package com.epam.coroutinecache.internal
 
-import kotlinx.coroutines.Deferred
 import java.util.concurrent.TimeUnit
+import kotlin.reflect.KCallable
 
 data class CacheObjectParams (
         var key: String = "",
@@ -9,5 +9,5 @@ data class CacheObjectParams (
         var timeUnit: TimeUnit = TimeUnit.MILLISECONDS,
         var isExpirable: Boolean = false,
         var useIfExpired: Boolean = false,
-        var loaderFun: Deferred<*>? = null
+        var loaderFun: KCallable<*>? = null
 )

--- a/core/src/main/java/com/epam/coroutinecache/internal/ProcessorProviderImpl.kt
+++ b/core/src/main/java/com/epam/coroutinecache/internal/ProcessorProviderImpl.kt
@@ -7,10 +7,10 @@ import com.epam.coroutinecache.core.actions.GetRecordAction
 import com.epam.coroutinecache.core.actions.SaveRecordAction
 import com.epam.coroutinecache.utils.CacheLog
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Deferred
 import org.koin.core.parameter.parametersOf
 import org.koin.standalone.KoinComponent
 import org.koin.standalone.inject
+import kotlin.reflect.full.callSuspend
 
 class ProcessorProviderImpl(
         private val cacheParams: CacheParams,
@@ -28,7 +28,7 @@ class ProcessorProviderImpl(
         val record = getRecordAction.getRecord<T>(cacheObjectParams.key, cacheObjectParams.useIfExpired)
         return if (record == null) {
             deleteRecordAction.deleteByKey(cacheObjectParams.key)
-            val data = (cacheObjectParams.loaderFun as? Deferred<T>)?.await()
+            val data = cacheObjectParams.loaderFun?.callSuspend() as T?
             saveRecordAction.save(cacheObjectParams.key, data, cacheObjectParams.timeUnit.toMillis(cacheObjectParams.lifeTime), cacheObjectParams.isExpirable).await()
             CacheLog.logMessage("Got data from source: ${Source.CLOUD}")
             data

--- a/core/src/main/java/com/epam/coroutinecache/internal/ProxyTranslator.kt
+++ b/core/src/main/java/com/epam/coroutinecache/internal/ProxyTranslator.kt
@@ -4,11 +4,11 @@ import com.epam.coroutinecache.annotations.Expirable
 import com.epam.coroutinecache.annotations.LifeTime
 import com.epam.coroutinecache.annotations.ProviderKey
 import com.epam.coroutinecache.annotations.UseIfExpired
-import kotlinx.coroutines.Deferred
 import java.lang.IllegalArgumentException
 import java.lang.IllegalStateException
 import java.lang.reflect.Method
 import java.util.concurrent.TimeUnit
+import kotlin.reflect.KCallable
 
 /**
  * Class that retrieves all object params from annotations and function that
@@ -18,7 +18,7 @@ class ProxyTranslator {
 
     private val cacheObjectParamsMap: MutableMap<Method, CacheObjectParams> = HashMap()
 
-    fun processMethod(method: Method?, objectMethods: Array<out Any>?): CacheObjectParams? {
+    fun processMethod(method: Method?, methodArgs: Array<out Any>?): CacheObjectParams? {
         if (method == null) {
             return null
         }
@@ -35,7 +35,8 @@ class ProxyTranslator {
         cacheObjectParams.isExpirable = isMethodExpirable(method)
         cacheObjectParams.useIfExpired = useMethodIfExpired(method)
         cacheObjectParams.key = getMethodKey(method)
-        cacheObjectParams.loaderFun = getDataDeferred(method, objectMethods)
+
+        cacheObjectParams.loaderFun = getDataSuspend(method, methodArgs)
 
         cacheObjectParamsMap[method] = cacheObjectParams
 
@@ -63,18 +64,18 @@ class ProxyTranslator {
         return annotation.key
     }
 
-    private fun getDataDeferred(method: Method, objectMethods: Array<out Any>?): Deferred<*> {
-        val deferred: Deferred<*> = getObjectFromMethodParam(method, Deferred::class.java, objectMethods) ?:
-                throw IllegalStateException("${method.name} requires an deferred instance")
-        return deferred
+    private fun getDataSuspend(method: Method, methodArgs: Array<out Any>?): KCallable<*> {
+        val dataProvider: KCallable<*>? = getObjectFromMethodParam(method, KCallable::class.java, methodArgs)
+        if (dataProvider == null || !dataProvider.isSuspend) throw IllegalStateException("${method.name} requires an suspend instance")
+        return dataProvider
     }
 
-    private fun <T> getObjectFromMethodParam(method: Method, expectedClass: Class<T>, objectMethods: Array<out Any>?): T? {
-        if (objectMethods == null) return null
+    private fun <T> getObjectFromMethodParam(method: Method, expectedClass: Class<T>, methodArgs: Array<out Any>?): T? {
+        if (methodArgs == null) return null
         var countSameObjectsType = 0
         var expectedObject: T? = null
 
-        for (objectParam in objectMethods) {
+        for (objectParam in methodArgs) {
             if (expectedClass.isAssignableFrom(objectParam!!::class.java)) {
                 expectedObject = objectParam as T
                 ++countSameObjectsType

--- a/core/src/main/java/com/epam/coroutinecache/internal/ProxyTranslator.kt
+++ b/core/src/main/java/com/epam/coroutinecache/internal/ProxyTranslator.kt
@@ -1,6 +1,5 @@
 package com.epam.coroutinecache.internal
 
-import com.epam.coroutinecache.annotations.*
 import com.epam.coroutinecache.utils.Types
 import com.epam.coroutinecache.annotations.Expirable
 import com.epam.coroutinecache.annotations.LifeTime


### PR DESCRIPTION
As suggested by Roman Elizarov in https://proandroiddev.com/caching-with-kotlin-coroutines-7d819276c820 comments, I started replacing Deferred with suspend functions